### PR TITLE
Abstraction for architecture dependent secure memset.

### DIFF
--- a/lib/source/ecc_dh.c
+++ b/lib/source/ecc_dh.c
@@ -57,6 +57,7 @@
 #include <tinycrypt/constants.h>
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dh.h>
+#include <tinycrypt/utils.h>
 #include <string.h>
 
 #if default_RNG_defined
@@ -92,7 +93,7 @@ int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 				       _public + curve->num_words);
 
 		/* erasing temporary buffer used to store secret: */
-		memset(_private, 0, NUM_ECC_BYTES);
+		_set_secure(_private, 0, NUM_ECC_BYTES);
 
 		return 1;
 	}
@@ -133,7 +134,7 @@ int uECC_make_key(uint8_t *public_key, uint8_t *private_key, uECC_Curve curve)
 					       _public + curve->num_words);
 
 			/* erasing temporary buffer that stored secret: */
-			memset(_private, 0, NUM_ECC_BYTES);
+			_set_secure(_private, 0, NUM_ECC_BYTES);
 
       			return 1;
     		}
@@ -189,12 +190,9 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 
 clear_and_out:
 	/* erasing temporary buffer used to store secret: */
-	memset(p2, 0, sizeof(p2));
-	__asm__ __volatile__("" :: "g"(p2) : "memory");
-	memset(tmp, 0, sizeof(tmp));
-	__asm__ __volatile__("" :: "g"(tmp) : "memory");
-	memset(_private, 0, sizeof(_private));
-	__asm__ __volatile__("" :: "g"(_private) : "memory");
+	_set_secure(p2, 0, sizeof(p2));
+	_set_secure(tmp, 0, sizeof(tmp));
+	_set_secure(_private, 0, sizeof(_private));
 
 	return r;
 }


### PR DESCRIPTION
In ecc_dh.c it is widely used to zero out the memory used for holding
sensitive information, such as private keys. This memory is cleared by
a memset, but as this is done right at function return, this memset
will most likely be optimized out by the compiler, as the memory will
no longer be used, hence no need to set it. To prevent the memset from
being optimized out, it is necessary to place a memory barrier at the
memset, but such a barrier is compiler depended.

To solve the above, a _set_secure function has been introduced. This
defaults to an inlined function calling memset and, in cases where the
compiler defines __GNUC__, adds a memory barrier which ensures that
the memset is not optimized out. For compilers, not defining the
__GNUC__, it may be necessary to define TINYCRYPT_ARCH_HAS_SET_SECURE
which then declares the _set_secure function extern, thus meaning that
it will require target implementation, which in turn allows for
architecture/compiler dependent implementation.

This also fixes the memset's in uECC_make_key and uECC_make_key_with_d
which actually was missing the memory barrier.

Fixes #32 
