### PR TITLE
Patch for #39 Sidechannel resistence of uECC_sign disabled

### DIFF
--- a/lib/source/ecc_dh.c
+++ b/lib/source/ecc_dh.c
@@ -60,12 +60,6 @@
 #include <tinycrypt/utils.h>
 #include <string.h>
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
-
 int uECC_make_key_with_d(uint8_t *public_key, uint8_t *private_key,
 			 unsigned int *d, uECC_Curve curve)
 {
@@ -174,7 +168,7 @@ int uECC_shared_secret(const uint8_t *public_key, const uint8_t *private_key,
 
 	/* If an RNG function was specified, try to get a random initial Z value to
 	 * improve protection against side-channel attacks. */
-	if (g_rng_function) {
+	if (uECC_get_rng()) {
 		if (!uECC_generate_random_int(p2[carry], curve->p, num_words)) {
 			r = 0;
 			goto clear_and_out;

--- a/lib/source/ecc_dsa.c
+++ b/lib/source/ecc_dsa.c
@@ -57,11 +57,6 @@
 #include <tinycrypt/ecc.h>
 #include <tinycrypt/ecc_dsa.h>
 
-#if default_RNG_defined
-static uECC_RNG_Function g_rng_function = &default_CSPRNG;
-#else
-static uECC_RNG_Function g_rng_function = 0;
-#endif
 
 static void bits2int(uECC_word_t *native, const uint8_t *bits,
 		     unsigned bits_size, uECC_Curve curve)
@@ -124,7 +119,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash,
 
 	/* If an RNG function was specified, get a random number
 	to prevent side channel analysis of k. */
-	if (!g_rng_function) {
+	if (!uECC_get_rng()) {
 		uECC_vli_clear(tmp, num_n_words);
 		tmp[0] = 1;
 	}


### PR DESCRIPTION
I removed the g_rng_function variable from ecc_dh.c, as there is another one in ecc.c.
I access the g_rng_function variable in ecc.c by the uECC_get_rng(). In this way, side-channel resistance should be enabled again.