### PR TITLE
Add support for SHA-512 message digest

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -17,6 +17,7 @@ OBJS:=aes_decrypt.o \
 	hmac.o \
 	hmac_prng.o \
 	sha256.o \
+	sha512.o \
 	ecc.o \
 	ecc_dh.o \
 	ecc_dsa.o \

--- a/lib/include/tinycrypt/sha512.h
+++ b/lib/include/tinycrypt/sha512.h
@@ -1,0 +1,129 @@
+/* sha512.h - TinyCrypt interface to a SHA-512 implementation */
+
+/*
+ *  Copyright (C) 2020 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief Interface to a SHA-512 implementation.
+ *
+ *  Overview:   SHA-512 is a NIST approved cryptographic hashing algorithm
+ *              specified in FIPS 180. A hash algorithm maps data of arbitrary
+ *              size to data of fixed length.
+ *
+ *  Security:   SHA-512 provides 256 bits of security against collision attacks
+ *              and 512 bits of security against pre-image attacks. SHA-512 does
+ *              NOT behave like a random oracle, but it can be used as one if
+ *              the string being hashed is prefix-free encoded before hashing.
+ *
+ *  Usage:      1) call tc_sha512_init to initialize a struct
+ *              tc_sha512_state_struct before hashing a new string.
+ *
+ *              2) call tc_sha512_update to hash the next string segment;
+ *              tc_sha512_update can be called as many times as needed to hash
+ *              all of the segments of a string; the order is important.
+ *
+ *              3) call tc_sha512_final to out put the digest from a hashing
+ *              operation.
+ */
+
+#ifndef __TC_SHA512_H__
+#define __TC_SHA512_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TC_SHA512_BLOCK_SIZE (128)
+#define TC_SHA512_DIGEST_SIZE (64)
+#define TC_SHA512_STATE_BLOCKS (TC_SHA512_DIGEST_SIZE/8)
+
+struct tc_sha512_state_struct {
+	uint64_t iv[TC_SHA512_STATE_BLOCKS];
+	uint64_t bits_hashed;
+	uint8_t leftover[TC_SHA512_BLOCK_SIZE];
+	size_t leftover_offset;
+};
+
+typedef struct tc_sha512_state_struct *TCSha512State_t;
+
+/**
+ *  @brief SHA512 initialization procedure
+ *  Initializes s
+ *  @return returns TC_CRYPTO_SUCCESS (1)
+ *          returns TC_CRYPTO_FAIL (0) if s == NULL
+ *  @param s Sha512 state struct
+ */
+int tc_sha512_init(TCSha512State_t s);
+
+/**
+ *  @brief SHA512 update procedure
+ *  Hashes data_length bytes addressed by data into state s
+ *  @return returns TC_CRYPTO_SUCCESS (1)
+ *          returns TC_CRYPTO_FAIL (0) if:
+ *                s == NULL,
+ *                s->iv == NULL,
+ *                data == NULL
+ *  @note Assumes s has been initialized by tc_sha512_init
+ *  @warning The state buffer 'leftover' is left in memory after processing
+ *           If your application intends to have sensitive data in this
+ *           buffer, remind to erase it after the data has been processed
+ *  @param s Sha512 state struct
+ *  @param data message to hash
+ *  @param datalen length of message to hash
+ */
+int tc_sha512_update (TCSha512State_t s, const uint8_t *data, size_t datalen);
+
+/**
+ *  @brief SHA512 final procedure
+ *  Inserts the completed hash computation into digest
+ *  @return returns TC_CRYPTO_SUCCESS (1)
+ *          returns TC_CRYPTO_FAIL (0) if:
+ *                s == NULL,
+ *                s->iv == NULL,
+ *                digest == NULL
+ *  @note Assumes: s has been initialized by tc_sha512_init
+ *        digest points to at least TC_SHA512_DIGEST_SIZE bytes
+ *  @warning The state buffer 'leftover' is left in memory after processing
+ *           If your application intends to have sensitive data in this
+ *           buffer, remind to erase it after the data has been processed
+ *  @param digest unsigned eight bit integer
+ *  @param Sha512 state struct
+ */
+int tc_sha512_final(uint8_t *digest, TCSha512State_t s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __TC_SHA512_H__ */

--- a/lib/source/sha512.c
+++ b/lib/source/sha512.c
@@ -1,0 +1,234 @@
+/* sha512.c - TinyCrypt SHA-512 crypto hash algorithm implementation */
+
+/*
+ *  Copyright (C) 2020 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <tinycrypt/sha512.h>
+#include <tinycrypt/constants.h>
+#include <tinycrypt/utils.h>
+
+static void compress(uint64_t *iv, const uint8_t *data);
+
+int tc_sha512_init(TCSha512State_t s)
+{
+	/* input sanity check: */
+	if (s == (TCSha512State_t) 0) {
+		return TC_CRYPTO_FAIL;
+	}
+
+	/*
+	 * Setting the initial state values.
+	 * These values correspond to the first 64 bits of the fractional parts
+	 * of the square roots of the first 8 primes: 2, 3, 5, 7, 11, 13, 17
+	 * and 19.
+	 */
+	_set((uint8_t *) s, 0x00, sizeof(*s));
+	s->iv[0] = 0x6a09e667f3bcc908;
+	s->iv[1] = 0xbb67ae8584caa73b;
+	s->iv[2] = 0x3c6ef372fe94f82b;
+	s->iv[3] = 0xa54ff53a5f1d36f1;
+	s->iv[4] = 0x510e527fade682d1;
+	s->iv[5] = 0x9b05688c2b3e6c1f;
+	s->iv[6] = 0x1f83d9abfb41bd6b;
+	s->iv[7] = 0x5be0cd19137e2179;
+
+	return TC_CRYPTO_SUCCESS;
+}
+
+int tc_sha512_update(TCSha512State_t s, const uint8_t *data, size_t datalen)
+{
+	/* input sanity check: */
+	if (s == (TCSha512State_t) 0 || data == (void *) 0) {
+		return TC_CRYPTO_FAIL;
+	} else if (datalen == 0) {
+		return TC_CRYPTO_SUCCESS;
+	}
+
+	while (datalen-- > 0) {
+		s->leftover[s->leftover_offset++] = *(data++);
+		if (s->leftover_offset >= TC_SHA512_BLOCK_SIZE) {
+			compress(s->iv, s->leftover);
+			s->leftover_offset = 0;
+			s->bits_hashed += (TC_SHA512_BLOCK_SIZE << 3);
+		}
+	}
+
+	return TC_CRYPTO_SUCCESS;
+}
+
+int tc_sha512_final(uint8_t *digest, TCSha512State_t s)
+{
+	unsigned int i;
+
+	/* input sanity check: */
+	if (digest == (uint8_t *) 0 || s == (TCSha512State_t) 0) {
+		return TC_CRYPTO_FAIL;
+	}
+
+	s->bits_hashed += (s->leftover_offset << 3);
+
+	s->leftover[s->leftover_offset++] = 0x80; /* always room for one byte */
+	if (s->leftover_offset > (sizeof(s->leftover) - 16)) {
+		/* there is not room for all the padding in this block */
+		_set(s->leftover + s->leftover_offset, 0x00,
+		     sizeof(s->leftover) - s->leftover_offset);
+		compress(s->iv, s->leftover);
+		s->leftover_offset = 0;
+	}
+
+	/*
+	 * add the padding and the length in big-Endian format
+	 *
+	 * NOTE: SHA-512 uses 128 bits for the length of the message, but the
+	 * current implementation is only using 64 bits for size, leaving the
+	 * 64 "upper" bits zeroed.
+	 */
+	_set(s->leftover + s->leftover_offset, 0x00,
+	     sizeof(s->leftover) - 8 - s->leftover_offset);
+	s->leftover[sizeof(s->leftover) - 1]  = (uint8_t)(s->bits_hashed);
+	s->leftover[sizeof(s->leftover) - 2]  = (uint8_t)(s->bits_hashed >> 8);
+	s->leftover[sizeof(s->leftover) - 3]  = (uint8_t)(s->bits_hashed >> 16);
+	s->leftover[sizeof(s->leftover) - 4]  = (uint8_t)(s->bits_hashed >> 24);
+	s->leftover[sizeof(s->leftover) - 5]  = (uint8_t)(s->bits_hashed >> 32);
+	s->leftover[sizeof(s->leftover) - 6]  = (uint8_t)(s->bits_hashed >> 40);
+	s->leftover[sizeof(s->leftover) - 7]  = (uint8_t)(s->bits_hashed >> 48);
+	s->leftover[sizeof(s->leftover) - 8]  = (uint8_t)(s->bits_hashed >> 56);
+
+	/* hash the padding and length */
+	compress(s->iv, s->leftover);
+
+	/* copy the iv out to digest */
+	for (i = 0; i < TC_SHA512_STATE_BLOCKS; ++i) {
+		uint64_t t = *((uint64_t *) &s->iv[i]);
+		*digest++ = (uint8_t)(t >> 56);
+		*digest++ = (uint8_t)(t >> 48);
+		*digest++ = (uint8_t)(t >> 40);
+		*digest++ = (uint8_t)(t >> 32);
+		*digest++ = (uint8_t)(t >> 24);
+		*digest++ = (uint8_t)(t >> 16);
+		*digest++ = (uint8_t)(t >> 8);
+		*digest++ = (uint8_t)(t);
+	}
+
+	/* destroy the current state */
+	_set(s, 0, sizeof(*s));
+
+	return TC_CRYPTO_SUCCESS;
+}
+
+/*
+ * Initializing SHA-512 Hash constant words K.
+ * These values correspond to the first 64 bits of the fractional parts of the
+ * cube roots of the first 80 primes between 2 and 409.
+ */
+static const uint64_t k512[80] = {
+	0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc, 0x3956c25bf348b538,
+	0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118, 0xd807aa98a3030242, 0x12835b0145706fbe,
+	0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2, 0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235,
+	0xc19bf174cf692694, 0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+	0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5, 0x983e5152ee66dfab,
+	0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4, 0xc6e00bf33da88fc2, 0xd5a79147930aa725,
+	0x06ca6351e003826f, 0x142929670a0e6e70, 0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed,
+	0x53380d139d95b3df, 0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+	0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30, 0xd192e819d6ef5218,
+	0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8, 0x19a4c116b8d2d0c8, 0x1e376c085141ab53,
+	0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8, 0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373,
+	0x682e6ff3d6b2b8a3, 0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+	0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b, 0xca273eceea26619c,
+	0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178, 0x06f067aa72176fba, 0x0a637dc5a2c898a6,
+	0x113f9804bef90dae, 0x1b710b35131c471b, 0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc,
+	0x431d67c49c100d4c, 0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817
+};
+
+static inline uint64_t ROTR(uint64_t a, uint64_t n)
+{
+	return (((a) >> n) | ((a) << (64 - n)));
+}
+
+#define Sigma0(a)(ROTR((a), 28) ^ ROTR((a), 34) ^ ROTR((a), 39))
+#define Sigma1(a)(ROTR((a), 14) ^ ROTR((a), 18) ^ ROTR((a), 41))
+#define sigma0(a)(ROTR((a), 1) ^ ROTR((a), 8) ^ ((a) >> 7))
+#define sigma1(a)(ROTR((a), 19) ^ ROTR((a), 61) ^ ((a) >> 6))
+
+#define Ch(a, b, c)(((a) & (b)) ^ ((~(a)) & (c)))
+#define Maj(a, b, c)(((a) & (b)) ^ ((a) & (c)) ^ ((b) & (c)))
+
+static inline uint64_t BigEndian(const uint8_t **c)
+{
+	uint64_t n = 0;
+
+	n  = (uint64_t)(*((*c)++)) << 56;
+	n |= (uint64_t)(*((*c)++)) << 48;
+	n |= (uint64_t)(*((*c)++)) << 40;
+	n |= (uint64_t)(*((*c)++)) << 32;
+	n |= (uint64_t)(*((*c)++)) << 24;
+	n |= (uint64_t)(*((*c)++)) << 16;
+	n |= (uint64_t)(*((*c)++)) << 8;
+	n |= (uint64_t)(*((*c)++));
+	return n;
+}
+
+static void compress(uint64_t *iv, const uint8_t *data)
+{
+	uint64_t a, b, c, d, e, f, g, h;
+	uint64_t s0, s1;
+	uint64_t t1, t2;
+	uint64_t work_space[16];
+	uint64_t n;
+	unsigned int i;
+
+	a = iv[0]; b = iv[1]; c = iv[2]; d = iv[3];
+	e = iv[4]; f = iv[5]; g = iv[6]; h = iv[7];
+
+	for (i = 0; i < 16; ++i) {
+		n = BigEndian(&data);
+		t1 = work_space[i] = n;
+		t1 += h + Sigma1(e) + Ch(e, f, g) + k512[i];
+		t2 = Sigma0(a) + Maj(a, b, c);
+		h = g; g = f; f = e; e = d + t1;
+		d = c; c = b; b = a; a = t1 + t2;
+	}
+
+	for ( ; i < 80; ++i) {
+		s0 = work_space[(i+1)&0x0f];
+		s0 = sigma0(s0);
+		s1 = work_space[(i+14)&0x0f];
+		s1 = sigma1(s1);
+
+		t1 = work_space[i&0xf] += s0 + s1 + work_space[(i+9)&0xf];
+		t1 += h + Sigma1(e) + Ch(e, f, g) + k512[i];
+		t2 = Sigma0(a) + Maj(a, b, c);
+		h = g; g = f; f = e; e = d + t1;
+		d = c; c = b; b = a; a = t1 + t2;
+	}
+
+	iv[0] += a; iv[1] += b; iv[2] += c; iv[3] += d;
+	iv[4] += e; iv[5] += f; iv[6] += g; iv[7] += h;
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,6 +56,9 @@ test_hmac_prng$(DOTEXE): test_hmac_prng.o hmac_prng.o hmac.o \
 test_sha256$(DOTEXE): test_sha256.o sha256.o utils.o
 	$(LINK.o) $^ $(LOADLIBES) $(LDLIBS) -o $@
 
+test_sha512$(DOTEXE): test_sha512.o sha512.o utils.o
+	$(LINK.o) $^ $(LOADLIBES) $(LDLIBS) -o $@
+
 test_ecc_dh$(DOTEXE): test_ecc_dh.o ecc.o ecc_dh.o test_ecc_utils.o ecc_platform_specific.o
 	$(LINK.o) $^ $(LOADLIBES) $(LDLIBS) -o $@
 

--- a/tests/test_sha512.c
+++ b/tests/test_sha512.c
@@ -1,0 +1,581 @@
+/*  test_sha512.c - TinyCrypt implementation of some SHA-512 tests */
+
+/*
+ *  Copyright (C) 2020 by Intel Corporation, All Rights Reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *    - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *    - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ *    - Neither the name of Intel Corporation nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+  DESCRIPTION
+  This module tests the following SHA512 routines:
+
+  Scenarios tested include:
+  - NIST SHA512 test vectors
+*/
+
+#include <tinycrypt/sha512.h>
+#include <tinycrypt/constants.h>
+#include <test_utils.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/*
+ * NIST SHA512 test vector 1.
+ */
+unsigned int test_1(void)
+{
+        unsigned int result = TC_PASS;
+
+        TC_PRINT("SHA512 test #1:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba,
+            0xcc, 0x41, 0x73, 0x49, 0xae, 0x20, 0x41, 0x31,
+            0x12, 0xe6, 0xfa, 0x4e, 0x89, 0xa9, 0x7e, 0xa2,
+            0x0a, 0x9e, 0xee, 0xe6, 0x4b, 0x55, 0xd3, 0x9a,
+            0x21, 0x92, 0x99, 0x2a, 0x27, 0x4f, 0xc1, 0xa8,
+            0x36, 0xba, 0x3c, 0x23, 0xa3, 0xfe, 0xeb, 0xbd,
+            0x45, 0x4d, 0x44, 0x23, 0x64, 0x3c, 0xe8, 0x0e,
+            0x2a, 0x9a, 0xc9, 0x4f, 0xa5, 0x4c, 0xa4, 0x9f,
+        };
+        const char *m = "abc";
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, (const uint8_t *) m, strlen(m));
+        (void)tc_sha512_final(digest, &s);
+        result = check_result(1, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+/*
+ * NIST SHA512 test vector 2.
+ */
+unsigned int test_2(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #2:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x20, 0x4a, 0x8f, 0xc6, 0xdd, 0xa8, 0x2f, 0x0a,
+            0x0c, 0xed, 0x7b, 0xeb, 0x8e, 0x08, 0xa4, 0x16,
+            0x57, 0xc1, 0x6e, 0xf4, 0x68, 0xb2, 0x28, 0xa8,
+            0x27, 0x9b, 0xe3, 0x31, 0xa7, 0x03, 0xc3, 0x35,
+            0x96, 0xfd, 0x15, 0xc1, 0x3b, 0x1b, 0x07, 0xf9,
+            0xaa, 0x1d, 0x3b, 0xea, 0x57, 0x78, 0x9c, 0xa0,
+            0x31, 0xad, 0x85, 0xc7, 0xa7, 0x1d, 0xd7, 0x03,
+            0x54, 0xec, 0x63, 0x12, 0x38, 0xca, 0x34, 0x45,
+        };
+        const char *m = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, (const uint8_t *) m, strlen(m));
+        (void) tc_sha512_final(digest, &s);
+
+        result = check_result(2, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_3(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #3:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x29, 0x6e, 0x22, 0x67, 0xd7, 0x4c, 0x27, 0x8d,
+            0xaa, 0xaa, 0x94, 0x0d, 0x17, 0xb0, 0xcf, 0xb7,
+            0x4a, 0x50, 0x83, 0xf8, 0xe0, 0x69, 0x72, 0x6d,
+            0x8c, 0x84, 0x1c, 0xbe, 0x59, 0x6e, 0x04, 0x31,
+            0xcb, 0x77, 0x41, 0xa5, 0xb5, 0x0f, 0x71, 0x66,
+            0x6c, 0xfd, 0x54, 0xba, 0xcb, 0x7b, 0x00, 0xae,
+            0xa8, 0x91, 0x49, 0x9c, 0xf4, 0xef, 0x6a, 0x03,
+            0xc8, 0xa8, 0x3f, 0xe3, 0x7c, 0x3f, 0x7b, 0xaf,
+        };
+        const uint8_t m[1] = { 0xbd };
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(3, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_4(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #4:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x09, 0xa9, 0x85, 0xc1, 0x5f, 0xa5, 0xcc, 0x68,
+            0xa8, 0x96, 0x8f, 0xfa, 0xea, 0xf3, 0xb5, 0xec,
+            0x23, 0x45, 0x69, 0xad, 0x56, 0x74, 0x50, 0x39,
+            0x4c, 0x07, 0x5b, 0x90, 0x61, 0xc8, 0xf7, 0xdf,
+            0x58, 0xff, 0x11, 0x29, 0x95, 0x70, 0x18, 0x82,
+            0x16, 0xc6, 0x31, 0xde, 0x60, 0x4d, 0xf0, 0xab,
+            0x08, 0xcd, 0xd1, 0x93, 0x29, 0x1c, 0xe5, 0x76,
+            0x3a, 0xcd, 0xc4, 0x27, 0xdf, 0x06, 0x04, 0x89,
+        };
+        const uint8_t m[4] = { 0xc9, 0x8c, 0x8e, 0x55 };
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(4, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_5(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #5:\n");
+
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x2c, 0x24, 0x81, 0x27, 0x8f, 0x62, 0xcd, 0x07,
+            0x72, 0x63, 0x83, 0xb0, 0x36, 0x77, 0x53, 0x06,
+            0xae, 0x6b, 0x69, 0x3f, 0x19, 0x9a, 0x6c, 0x70,
+            0x0f, 0x73, 0x5f, 0xe2, 0x25, 0x07, 0xc9, 0x08,
+            0x4b, 0xb9, 0x1c, 0xe5, 0xf6, 0x45, 0x8d, 0x3c,
+            0x39, 0x26, 0x51, 0x49, 0x70, 0x22, 0x6c, 0x56,
+            0x34, 0x64, 0x72, 0x3a, 0xa9, 0x9c, 0x21, 0x0b,
+            0x77, 0x51, 0x88, 0x30, 0x57, 0x6f, 0x8c, 0x0b,
+        };
+        uint8_t m[55];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(5, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_6(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #6:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x21, 0x46, 0xaa, 0x8a, 0xb6, 0x0c, 0x48, 0xac,
+            0xff, 0x43, 0xae, 0x8c, 0x33, 0xc5, 0xda, 0x4c,
+            0x25, 0x86, 0xf2, 0x0a, 0x39, 0xf8, 0xf1, 0x30,
+            0x8a, 0xef, 0xb6, 0xf8, 0x33, 0xb7, 0x58, 0xad,
+            0x71, 0x58, 0xbd, 0x5e, 0x9a, 0x38, 0x6e, 0x45,
+            0xfe, 0xba, 0x44, 0x6f, 0x33, 0x85, 0x5d, 0x39,
+            0x38, 0x57, 0xb5, 0x57, 0xfe, 0x8b, 0xa6, 0xfe,
+            0x52, 0x36, 0x4e, 0x7a, 0x7a, 0xf3, 0xbe, 0x9b,
+        };
+        uint8_t m[56];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(6, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_7(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #7:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x90, 0x4f, 0x18, 0x92, 0xec, 0x5c, 0x43, 0xc5,
+            0x57, 0x19, 0x93, 0x25, 0xfd, 0xa7, 0x9c, 0xac,
+            0xae, 0xe2, 0xe8, 0xf1, 0xb4, 0xa1, 0xd4, 0x1b,
+            0x85, 0xc8, 0x93, 0xd9, 0x67, 0xc3, 0x20, 0x9f,
+            0x0c, 0x58, 0x08, 0x1c, 0x0c, 0x9a, 0x60, 0x83,
+            0xf8, 0x5f, 0xd4, 0x86, 0x66, 0x11, 0xdf, 0xeb,
+            0x49, 0x0c, 0x11, 0xf3, 0x16, 0x3c, 0x12, 0xf4,
+            0xf0, 0x57, 0x9a, 0xdd, 0xa2, 0xc6, 0x81, 0x00,
+        };
+        uint8_t m[57];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(7, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_8(void)
+{
+        unsigned int result = TC_PASS;
+
+        TC_PRINT("SHA512 test #8:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x7b, 0xe9, 0xfd, 0xa4, 0x8f, 0x41, 0x79, 0xe6,
+            0x11, 0xc6, 0x98, 0xa7, 0x3c, 0xff, 0x09, 0xfa,
+            0xf7, 0x28, 0x69, 0x43, 0x1e, 0xfe, 0xe6, 0xea,
+            0xad, 0x14, 0xde, 0x0c, 0xb4, 0x4b, 0xbf, 0x66,
+            0x50, 0x3f, 0x75, 0x2b, 0x7a, 0x8e, 0xb1, 0x70,
+            0x83, 0x35, 0x5f, 0x3c, 0xe6, 0xeb, 0x7d, 0x28,
+            0x06, 0xf2, 0x36, 0xb2, 0x5a, 0xf9, 0x6a, 0x24,
+            0xe2, 0x2b, 0x88, 0x74, 0x05, 0xc2, 0x00, 0x81,
+        };
+        uint8_t m[64];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(8, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_9(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #9:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0xca, 0x3d, 0xff, 0x61, 0xbb, 0x23, 0x47, 0x7a,
+            0xa6, 0x08, 0x7b, 0x27, 0x50, 0x82, 0x64, 0xa6,
+            0xf9, 0x12, 0x6e, 0xe3, 0xa0, 0x04, 0xf5, 0x3c,
+            0xb8, 0xdb, 0x94, 0x2e, 0xd3, 0x45, 0xf2, 0xf2,
+            0xd2, 0x29, 0xb4, 0xb5, 0x9c, 0x85, 0x92, 0x20,
+            0xa1, 0xcf, 0x19, 0x13, 0xf3, 0x42, 0x48, 0xe3,
+            0x80, 0x3b, 0xab, 0x65, 0x0e, 0x84, 0x9a, 0x3d,
+            0x9a, 0x70, 0x9e, 0xdc, 0x09, 0xae, 0x4a, 0x76,
+        };
+        uint8_t m[1000];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(9, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_10(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #10:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x32, 0x9c, 0x52, 0xac, 0x62, 0xd1, 0xfe, 0x73,
+            0x11, 0x51, 0xf2, 0xb8, 0x95, 0xa0, 0x04, 0x75,
+            0x44, 0x5e, 0xf7, 0x4f, 0x50, 0xb9, 0x79, 0xc6,
+            0xf7, 0xbb, 0x7c, 0xae, 0x34, 0x93, 0x28, 0xc1,
+            0xd4, 0xcb, 0x4f, 0x72, 0x61, 0xa0, 0xab, 0x43,
+            0xf9, 0x36, 0xa2, 0x4b, 0x00, 0x06, 0x51, 0xd4,
+            0xa8, 0x24, 0xfc, 0xdd, 0x57, 0x7f, 0x21, 0x1a,
+            0xef, 0x8f, 0x80, 0x6b, 0x16, 0xaf, 0xe8, 0xaf,
+        };
+        uint8_t m[1000];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x41, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(10, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_11(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #11:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x59, 0xf5, 0xe5, 0x4f, 0xe2, 0x99, 0xc6, 0xa8,
+            0x76, 0x4c, 0x6b, 0x19, 0x9e, 0x44, 0x92, 0x4a,
+            0x37, 0xf5, 0x9e, 0x2b, 0x56, 0xc3, 0xeb, 0xad,
+            0x93, 0x9b, 0x72, 0x89, 0x21, 0x0d, 0xc8, 0xe4,
+            0xc2, 0x1b, 0x97, 0x20, 0x16, 0x5b, 0x0f, 0x4d,
+            0x43, 0x74, 0xc9, 0x0f, 0x1b, 0xf4, 0xfb, 0x4a,
+            0x5a, 0xce, 0x17, 0xa1, 0x16, 0x17, 0x98, 0x01,
+            0x50, 0x52, 0x89, 0x3a, 0x48, 0xc3, 0xd1, 0x61,
+        };
+        uint8_t m[1005];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+
+        (void)memset(m, 0x55, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        tc_sha512_update(&s, m, sizeof(m));
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(11, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_12(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #12:\n");
+
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0xce, 0x04, 0x4b, 0xc9, 0xfd, 0x43, 0x26, 0x9d,
+            0x5b, 0xbc, 0x94, 0x6c, 0xbe, 0xbc, 0x3b, 0xb7,
+            0x11, 0x34, 0x11, 0x15, 0xcc, 0x4a, 0xbd, 0xf2,
+            0xed, 0xbc, 0x3f, 0xf2, 0xc5, 0x7a, 0xd4, 0xb1,
+            0x5d, 0xeb, 0x69, 0x9b, 0xda, 0x25, 0x7f, 0xea,
+            0x5a, 0xef, 0x9c, 0x6e, 0x55, 0xfc, 0xf4, 0xcf,
+            0x9d, 0xc2, 0x5a, 0x8c, 0x3c, 0xe2, 0x5f, 0x2e,
+            0xfe, 0x90, 0x90, 0x83, 0x79, 0xbf, 0xf7, 0xed,
+        };
+        uint8_t m[1000];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+        unsigned int i;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        for (i = 0; i < 1000; ++i) {
+                tc_sha512_update(&s, m, sizeof(m));
+        }
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(12, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_13(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #13:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0xda, 0x17, 0x22, 0x79, 0xf3, 0xeb, 0xbd, 0xa9,
+            0x5f, 0x6b, 0x6e, 0x1e, 0x5f, 0x0e, 0xbe, 0xc6,
+            0x82, 0xc2, 0x5d, 0x3d, 0x93, 0x56, 0x1a, 0x16,
+            0x24, 0xc2, 0xfa, 0x90, 0x09, 0xd6, 0x4c, 0x7e,
+            0x99, 0x23, 0xf3, 0xb4, 0x6b, 0xca, 0xf1, 0x1d,
+            0x39, 0xa5, 0x31, 0xf4, 0x32, 0x97, 0x99, 0x2b,
+            0xa4, 0x15, 0x5c, 0x7e, 0x82, 0x7b, 0xd0, 0xf1,
+            0xe1, 0x94, 0xae, 0x7e, 0xd6, 0xde, 0x4c, 0xac,
+        };
+        uint8_t m[32768];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+        unsigned int i;
+
+        (void)memset(m, 0x5a, sizeof(m));
+
+        (void)tc_sha512_init(&s);
+        for (i = 0; i < 16384; ++i) {
+                tc_sha512_update(&s, m, sizeof(m));
+        }
+        (void)tc_sha512_final(digest, &s);
+
+        result = check_result(13, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+unsigned int test_14(void)
+{
+        unsigned int result = TC_PASS;
+        TC_PRINT("SHA512 test #14:\n");
+        const uint8_t expected[TC_SHA512_DIGEST_SIZE] = {
+            0x14, 0xb1, 0xbe, 0x90, 0x1c, 0xb4, 0x35, 0x49,
+            0xb4, 0xd8, 0x31, 0xe6, 0x1e, 0x5f, 0x9d, 0xf1,
+            0xc7, 0x91, 0xc8, 0x5b, 0x50, 0xe8, 0x5f, 0x9d,
+            0x6b, 0xc6, 0x41, 0x35, 0x80, 0x4a, 0xd4, 0x3c,
+            0xe8, 0x40, 0x27, 0x50, 0xed, 0xbe, 0x4e, 0x5c,
+            0x0f, 0xc1, 0x70, 0xb9, 0x9c, 0xf7, 0x8b, 0x9f,
+            0x4e, 0xcb, 0x9c, 0x7e, 0x02, 0xa1, 0x57, 0x91,
+            0x1d, 0x1b, 0xd1, 0x83, 0x2d, 0x76, 0x78, 0x4f,
+        };
+        uint8_t m[32768];
+        uint8_t digest[TC_SHA512_DIGEST_SIZE];
+        struct tc_sha512_state_struct s;
+        unsigned int i;
+
+        (void)memset(m, 0x00, sizeof(m));
+
+        (void) tc_sha512_init(&s);
+        for (i = 0; i < 33280; ++i) {
+                tc_sha512_update(&s, m, sizeof(m));
+        }
+        (void) tc_sha512_final(digest, &s);
+
+        result = check_result(14, expected, sizeof(expected),
+                digest, sizeof(digest));
+        TC_END_RESULT(result);
+        return result;
+}
+
+/*
+ * Main task to test SHA512
+ */
+
+int main(void)
+{
+        unsigned int result = TC_PASS;
+        TC_START("Performing SHA512 tests (NIST tests vectors):");
+
+        result = test_1();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #1 failed.\n");
+                goto exitTest;
+        }
+        result = test_2();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #2 failed.\n");
+                goto exitTest;
+        }
+        result = test_3();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #3 failed.\n");
+                goto exitTest;
+        }
+        result = test_4();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #4 failed.\n");
+                goto exitTest;
+        }
+        result = test_5();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #5 failed.\n");
+                goto exitTest;
+        }
+        result = test_6();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #6 failed.\n");
+                goto exitTest;
+        }
+        result = test_7();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #7 failed.\n");
+                goto exitTest;
+        }
+        result = test_8();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #8 failed.\n");
+                goto exitTest;
+        }
+        result = test_9();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #9 failed.\n");
+                goto exitTest;
+        }
+        result = test_10();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #10 failed.\n");
+                goto exitTest;
+        }
+        result = test_11();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #11 failed.\n");
+                goto exitTest;
+        }
+        result = test_12();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #12 failed.\n");
+                goto exitTest;
+        }
+        /* memory and computation intensive test cases: */
+        result = test_13();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #13 failed.\n");
+                goto exitTest;
+        }
+        result = test_14();
+        if (result == TC_FAIL) {
+                /* terminate test */
+                TC_ERROR("SHA512 test #14 failed.\n");
+                goto exitTest;
+        }
+
+        TC_PRINT("All SHA512 tests succeeded!\n");
+
+exitTest:
+        TC_END_RESULT(result);
+        TC_END_REPORT(result);
+}
+


### PR DESCRIPTION
This adds SHA-512, which is based on the current SHA-256 code, with the small changes to accommodate the differences between both message digests. I left the license headers basically the same with updated copyright year.

The main reason for adding this is because ed25519 requires the use of SHA-512, and we support ed25519 signature checking in https://github.com/JuulLabs-OSS/mcuboot/, but it currently depends on mbedTLS. With this change it would be possible to build ed25519 validation with our bundled Tinycrypt.