### PR TITLE
tinycrypt: fix asan report error

### DIFF
--- a/lib/source/aes_encrypt.c
+++ b/lib/source/aes_encrypt.c
@@ -64,7 +64,7 @@ static inline unsigned int rotword(unsigned int a)
 	return (((a) >> 24)|((a) << 8));
 }
 
-#define subbyte(a, o)(sbox[((a) >> (o))&0xff] << (o))
+#define subbyte(a, o)((uint32_t)sbox[((a) >> (o))&0xff] << (o))
 #define subword(a)(subbyte(a, 24)|subbyte(a, 16)|subbyte(a, 8)|subbyte(a, 0))
 
 int tc_aes128_set_encrypt_key(TCAesKeySched_t s, const uint8_t *k)


### PR DESCRIPTION
lib/source/aes_encrypt.c:93:8: runtime error: left shift of 251 by 24 places cannot be represented in type 'int'
