### PR TITLE
tinycrypt: Use a do..while loop and remove explicit CC

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -7,7 +7,6 @@
 ################################################################################
 
 # EDIT HERE:
-CC:=gcc
 CFLAGS:=-Os -std=c99 -Wall -Wextra -D_ISOC99_SOURCE -MMD -I../lib/include/ -I../lib/source/ -I../tests/include/
 vpath %.c ../lib/source/
 ENABLE_TESTS=true
@@ -27,7 +26,6 @@ else
 CFLAGS += -DDISABLE_TESTS
 endif
 
-export CC
 export CFLAGS
 export VPATH
 export ENABLE_TESTS

--- a/lib/source/ctr_prng.c
+++ b/lib/source/ctr_prng.c
@@ -52,13 +52,12 @@
  */
 static void arrInc(uint8_t arr[], unsigned int len)
 {
-	unsigned int i;
 	if (0 != arr) {
-		for (i = len; i > 0U; i--) {
-			if (++arr[i-1] != 0U) {
+		do {
+			if (++arr[len - 1] != 0) {
 				break;
 			}
-		}
+		} while (len--);
 	}
 }
 


### PR DESCRIPTION
Hello,
1. In `ctr_prng.c`, the `arrInc()` function uses a for loop which requires defining a variable before initializing. As we're already going backward there, we can just replace the for loop with a `do..while` loop instead. 
2. Makefile explicitly uses GCC, however, most BSD systems don't use GCC, instead, they ship Clang by default. Dropping explicitly stating the compiler is much better as we can safely assume the `CC` variable already defaults to an existing/installed compiler.